### PR TITLE
Fix: Default cut off

### DIFF
--- a/theme/src/main/res/values-v27/styles.xml
+++ b/theme/src/main/res/values-v27/styles.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="AppTheme" parent="AppTheme.Base">
+        <!-- Black navigation bar. -->
+        <item name="android:navigationBarColor">@android:color/black</item>
+        <!-- Use white status bar text on any theme. -->
+        <item name="android:windowLightStatusBar">false</item>
+        <!-- The default cutoff has to be set so that nothing is drawn in landscape mode
+             on the cutoff area.
+         -->
+        <item name="android:windowLayoutInDisplayCutoutMode">default</item>
+    </style>
+</resources>


### PR DESCRIPTION
This PR fixes how the apps are rendered on phones with cutoff area in landscape mode. The `default` mode is used, so the app is cut.
More: https://developer.android.com/guide/topics/display-cutout