### PR TITLE
Migration to Compose 1.3 using new BOM

### DIFF
--- a/analytics/build.gradle
+++ b/analytics/build.gradle
@@ -65,22 +65,22 @@ dependencies {
     implementation project(":core")
     implementation project(":theme")
 
-    // Fundamental components of compose UI
-    implementation "androidx.compose.ui:ui:$compose_version"
-    // Previews
-    implementation "androidx.compose.ui:ui-tooling:$compose_version"
-    // Foundation (Border, Background, Box, Image, Scroll, shapes, animations, etc.)
-    implementation "androidx.compose.foundation:foundation:$compose_version"
+    implementation platform("androidx.compose:compose-bom:$compose_version")
     // Material 3
-    implementation "androidx.compose.material3:material3:$material3_version"
+    implementation "androidx.compose.material3:material3"
+    // Android Studio Preview support
+    implementation 'androidx.compose.ui:ui-tooling-preview'
+    debugImplementation 'androidx.compose.ui:ui-tooling'
     // Data Store
     implementation "androidx.datastore:datastore-preferences:1.0.0"
 
+    // Dagger and Hilt
     implementation "com.google.dagger:hilt-android:$dagger_version"
     kapt "com.google.dagger:hilt-android-compiler:$dagger_version"
     implementation "androidx.hilt:hilt-navigation-compose:1.0.0"
 
-    implementation platform('com.google.firebase:firebase-bom:30.5.0')
+    // Firebase for Analytics
+    implementation platform('com.google.firebase:firebase-bom:31.0.1')
     implementation 'com.google.firebase:firebase-analytics-ktx'
     implementation 'com.google.firebase:firebase-crashlytics-ktx'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -50,18 +50,17 @@ dependencies {
     implementation project(":navigation")
     implementation project(":permission")
 
-    // Fundamental components of compose UI
-    implementation "androidx.compose.ui:ui:$compose_version"
-    // Previews
-    implementation "androidx.compose.ui:ui-tooling:$compose_version"
-    // Foundation (Border, Background, Box, Image, Scroll, shapes, animations, etc.)
-    implementation "androidx.compose.foundation:foundation:$compose_version"
+    implementation platform("androidx.compose:compose-bom:$compose_version")
     // Material 3
-    implementation "androidx.compose.material3:material3:$material3_version"
-    implementation "androidx.compose.material:material-icons-extended:$compose_version"
+    implementation "androidx.compose.material3:material3"
+    implementation "androidx.compose.material:material-icons-extended"
+    // Android Studio Preview support
+    implementation 'androidx.compose.ui:ui-tooling-preview'
+    debugImplementation 'androidx.compose.ui:ui-tooling'
     // Integration with activities
-    implementation "androidx.activity:activity-compose:1.6.0"
+    implementation "androidx.activity:activity-compose:1.6.1"
 
+    // Dagger and Hilt
     implementation "com.google.dagger:hilt-android:$dagger_version"
     kapt "com.google.dagger:hilt-android-compiler:$dagger_version"
     implementation "androidx.hilt:hilt-navigation-compose:1.0.0"

--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,10 @@ buildscript {
 
     ext {
         kotlin_version = '1.7.20'
-        compose_version = '1.3.0-rc01'
+        compose_version = '2022.10.00'
         compose_compiler_version = '1.3.2'
-        material3_version = '1.0.0-rc01'
         dagger_version = '2.44'
+
         android_api_version = 33
         android_min_api_version = 21
     }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -30,8 +30,9 @@ android {
 }
 
 dependencies {
+    implementation platform("androidx.compose:compose-bom:$compose_version")
     // Fundamental components of compose UI
-    implementation "androidx.compose.ui:ui:$compose_version"
+    implementation "androidx.compose.ui:ui"
 }
 
 // === Maven Central configuration ===

--- a/navigation/build.gradle
+++ b/navigation/build.gradle
@@ -42,13 +42,18 @@ kapt {
 }
 
 dependencies {
+    implementation platform("androidx.compose:compose-bom:$compose_version")
     // Fundamental components of compose UI
-    implementation "androidx.compose.ui:ui:$compose_version"
+    implementation "androidx.compose.ui:ui"
+    // Android Studio Preview support
+    implementation 'androidx.compose.ui:ui-tooling-preview'
+    debugImplementation 'androidx.compose.ui:ui-tooling'
     // Integration with activities
-    implementation "androidx.activity:activity-compose:1.6.0"
+    implementation "androidx.activity:activity-compose:1.6.1"
     // Navigation
-    implementation "androidx.navigation:navigation-compose:2.6.0-alpha02"
+    implementation "androidx.navigation:navigation-compose:2.6.0-alpha03"
 
+    // Dagger and Hilt
     implementation "com.google.dagger:hilt-android:$dagger_version"
     kapt "com.google.dagger:hilt-android-compiler:$dagger_version"
     implementation "androidx.hilt:hilt-navigation-compose:1.0.0"

--- a/permission/build.gradle
+++ b/permission/build.gradle
@@ -46,17 +46,13 @@ dependencies {
     implementation project(":theme")
     implementation project(":navigation")
 
-    implementation "com.google.accompanist:accompanist-flowlayout:0.26.4-beta"
-
-    // Fundamental components of compose UI
-    implementation "androidx.compose.ui:ui:$compose_version"
-    // Previews
-    implementation "androidx.compose.ui:ui-tooling:$compose_version"
-    // Foundation (Border, Background, Box, Image, Scroll, shapes, animations, etc.)
-    implementation "androidx.compose.foundation:foundation:$compose_version"
+    implementation platform("androidx.compose:compose-bom:$compose_version")
     // Material 3
-    implementation "androidx.compose.material3:material3:$material3_version"
-    implementation "androidx.compose.material:material-icons-extended:$compose_version"
+    implementation "androidx.compose.material3:material3"
+    implementation "androidx.compose.material:material-icons-extended"
+    // Android Studio Preview support
+    implementation 'androidx.compose.ui:ui-tooling-preview'
+    debugImplementation 'androidx.compose.ui:ui-tooling'
 
     implementation "com.google.dagger:hilt-android:$dagger_version"
     kapt "com.google.dagger:hilt-android-compiler:$dagger_version"

--- a/theme/build.gradle
+++ b/theme/build.gradle
@@ -32,24 +32,22 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.core:core-splashscreen:1.0.0'
-
-    implementation "com.google.accompanist:accompanist-pager:0.26.4-beta"
-    implementation "com.google.accompanist:accompanist-pager-indicators:0.26.4-beta"
-
-    implementation 'com.github.jeziellago:compose-markdown:0.3.0'
-
-    // Fundamental components of compose UI
-    implementation "androidx.compose.ui:ui:$compose_version"
-    // Previews
-    implementation "androidx.compose.ui:ui-tooling:$compose_version"
-    // Foundation (Border, Background, Box, Image, Scroll, shapes, animations, etc.)
-    implementation "androidx.compose.foundation:foundation:$compose_version"
-    // Material You
-    implementation "androidx.compose.material3:material3:$material3_version"
-    implementation "androidx.compose.material:material-icons-extended:$compose_version"
+    implementation platform("androidx.compose:compose-bom:$compose_version")
+    // Material 3
+    implementation "androidx.compose.material3:material3"
+    implementation "androidx.compose.material:material-icons-extended"
+    // Android Studio Preview support
+    implementation 'androidx.compose.ui:ui-tooling-preview'
+    debugImplementation 'androidx.compose.ui:ui-tooling'
     // Integration with activities
-    implementation "androidx.activity:activity-compose:1.6.0"
+    implementation "androidx.activity:activity-compose:1.6.1"
+    // Splash Screen
+    implementation 'androidx.core:core-splashscreen:1.0.0'
+    // Pager with indicators
+    implementation "com.google.accompanist:accompanist-pager:0.27.0"
+    implementation "com.google.accompanist:accompanist-pager-indicators:0.27.0"
+    // Markdown
+    implementation 'com.github.jeziellago:compose-markdown:0.3.0'
 }
 
 // === Maven Central configuration ===

--- a/uilogger/build.gradle
+++ b/uilogger/build.gradle
@@ -42,17 +42,17 @@ kapt {
 
 dependencies {
     implementation project(":theme")
+
+    implementation platform("androidx.compose:compose-bom:$compose_version")
+    // Material 3
+    implementation "androidx.compose.material3:material3"
+    // Android Studio Preview support
+    implementation 'androidx.compose.ui:ui-tooling-preview'
+    debugImplementation 'androidx.compose.ui:ui-tooling'
+    // nRF Logger
     implementation "no.nordicsemi.android:log:2.3.0"
 
-    // Fundamental components of compose UI
-    implementation "androidx.compose.ui:ui:$compose_version"
-    // Previews
-    implementation "androidx.compose.ui:ui-tooling:$compose_version"
-    // Foundation (Border, Background, Box, Image, Scroll, shapes, animations, etc.)
-    implementation "androidx.compose.foundation:foundation:$compose_version"
-    // Material 3
-    implementation "androidx.compose.material3:material3:$material3_version"
-
+    // Dagger and Hilt
     implementation "com.google.dagger:hilt-android:$dagger_version"
     kapt "com.google.dagger:hilt-android-compiler:$dagger_version"
 }

--- a/uiscanner/build.gradle
+++ b/uiscanner/build.gradle
@@ -46,23 +46,19 @@ dependencies {
     implementation project(":theme")
     implementation project(":permission")
 
-    implementation "com.google.accompanist:accompanist-flowlayout:0.26.4-beta"
-    implementation "com.google.accompanist:accompanist-swiperefresh:0.26.4-beta"
+    implementation "com.google.accompanist:accompanist-flowlayout:0.27.0"
+    implementation "com.google.accompanist:accompanist-swiperefresh:0.27.0"
 
-    // Fundamental components of compose UI
-    implementation "androidx.compose.ui:ui:$compose_version"
-    // Previews
-    implementation "androidx.compose.ui:ui-tooling:$compose_version"
-    // Foundation (Border, Background, Box, Image, Scroll, shapes, animations, etc.)
-    implementation "androidx.compose.foundation:foundation:$compose_version"
+    implementation platform("androidx.compose:compose-bom:$compose_version")
     // Material 3
-    implementation "androidx.compose.material3:material3:$material3_version"
+    implementation "androidx.compose.material3:material3"
     // Material design icons
-    implementation "androidx.compose.material:material-icons-core:$compose_version"
-    implementation "androidx.compose.material:material-icons-extended:$compose_version"
+    implementation "androidx.compose.material:material-icons-extended"
+    // Android Studio Preview support
+    implementation 'androidx.compose.ui:ui-tooling-preview'
+    debugImplementation 'androidx.compose.ui:ui-tooling'
     // Integration with activities
-    implementation "androidx.activity:activity-compose:1.6.0"
-
+    implementation "androidx.activity:activity-compose:1.6.1"
     // Brings the new BluetoothLeScanner API to older platforms
     implementation "no.nordicsemi.android.support.v18:scanner:1.6.0"
 


### PR DESCRIPTION
This PR migrates to Compose 1.3.0 and Material 3 1.0.0 using BOM `2022.10.00`.