### PR TITLE
Bug fix for navigation to simple destination without any arguments

### DIFF
--- a/navigation/src/main/java/no/nordicsemi/android/common/navigation/NavigationDestination.kt
+++ b/navigation/src/main/java/no/nordicsemi/android/common/navigation/NavigationDestination.kt
@@ -81,7 +81,7 @@ fun <A, R> createDestination(name: String): DestinationId<A, R> = DestinationId(
  *
  * The destination does not take any arguments and does not return any result.
  */
-fun createSimpleDestination(name: String): DestinationId<Unit, Unit> = DestinationId(name)
+fun createSimpleDestination(name: String): DestinationId<Unit?, Unit?> = DestinationId(name)
 
 /**
  * Helper method for creating a [NavigationDestination].


### PR DESCRIPTION
For reference, this is the branch on which I migrated to 1.2.0
[https://github.com/Pap36/Android-nRF-MeshSniffer/tree/migration](url)

When tying to migrate to version 1.2.0 the following occurred. First, the project wouldn't build and the error
```
> Task :ui:sessions:compileDebugKotlin FAILED
e: Pre-release classes were found in dependencies. Remove them from the classpath, recompile with a release compiler or use '-Xskip-prerelease-check' to suppress errors
e: C:\Users\pap1\AndroidStudioProjects\Android-nRF-MeshSniffer\ui\sessions\src\main\java\no\nordicsemi\android\mesh\sniffer\ui\sessions\SessionsDestination.kt: (19, 42): Class 'no.nordicsemi.android.mesh.sniffer.ui.access.AccessDestinationKt' is compiled by a pre-release version of Kotlin and cannot be loaded by this version of the compiler

> Task :app:mergeExtDexDebug

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':ui:sessions:compileDebugKotlin'.
> A failure occurred while executing org.jetbrains.kotlin.compilerRunner.GradleCompilerRunnerWithWorkers$GradleKotlinCompilerWorkAction
   > Compilation error. See log for more details

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 14s
```
Following up on the suggestion this was fixed by adding 
```
kotlinOptions {
    freeCompilerArgs = freeCompilerArgs + "-Xskip-prerelease-check"
}
``` 
to ```build.gradle``` for the ```sessions``` module in Android-nRF-MeshSniffer. The current navigation structure of my project is
```sessions``` ----```onClick(scanSession)```----> ```access```
```sessions``` ----```onClick(Settings)``` ----> ```settings```
```access``` ---- ```onClick(Network)``` ----> ```network```
Pressing back follows the above graph in reverse. What I find interesting is that the ```access``` module also performs navigation in between modules using ```simpleDestination```, yet the compiler options were not required in this module's build file. The only difference between the ```sessions``` module and the ```access``` module is that the former has the compiler options modifying the arguments, whereas the latter has the language version set to ```1.8```. If we modify the ```sessions``` module to use the language version and remove the compiler arguments then the project builds correctly. Will use this solution.

The main issue of this pull request is however when simple navigation is performed without any arguments. For example
```
val Sessions = createSimpleDestination("sessions")

val SessionsDestination = defineDestination(Sessions) {

    val viewModel: SimpleNavigationViewModel = hiltViewModel()

    ScanSessionsScreen(
        onClick = { viewModel.navigateTo(Access, null) },
    )
}
```
Note that this is the only working way at the moment after performing the change in this pull request. Before, the ```args``` parameter was mandatory to be passed. Also, passing ```Unit``` resulted in an error. This is probably not the best fix but me and @sylwester-zielinski played with this yesterday and found out that this works.

@sylwester-zielinski the change in ```Kotlin-nRF-Mesh``` was not necessary as the main issue was with the compiler settings in my modules + the optional parameter being required.
