### PR TITLE
Bug fix: stop scanning when scanner not visible

### DIFF
--- a/uiscanner/src/main/java/no/nordicsemi/android/common/ui/scanner/ScannerView.kt
+++ b/uiscanner/src/main/java/no/nordicsemi/android/common/ui/scanner/ScannerView.kt
@@ -56,6 +56,7 @@ import no.nordicsemi.android.common.ui.scanner.main.DeviceListItem
 import no.nordicsemi.android.common.ui.scanner.main.DevicesListView
 import no.nordicsemi.android.common.ui.scanner.main.viewmodel.ScannerViewModel
 import no.nordicsemi.android.common.ui.scanner.model.DiscoveredBluetoothDevice
+import no.nordicsemi.android.common.ui.scanner.repository.ScanningState
 import no.nordicsemi.android.common.ui.scanner.view.internal.FilterView
 
 @OptIn(ExperimentalMaterialApi::class, ExperimentalLifecycleComposeApi::class)
@@ -77,7 +78,7 @@ fun ScannerView(
             val viewModel = hiltViewModel<ScannerViewModel>()
                 .apply { setFilterUuid(uuid) }
 
-            val state by viewModel.state.collectAsStateWithLifecycle()
+            val state by viewModel.state.collectAsStateWithLifecycle(ScanningState.Loading)
             val config by viewModel.filterConfig.collectAsStateWithLifecycle()
             var refreshing by remember { mutableStateOf(false) }
 

--- a/uiscanner/src/main/java/no/nordicsemi/android/common/ui/scanner/main/viewmodel/ScannerViewModel.kt
+++ b/uiscanner/src/main/java/no/nordicsemi/android/common/ui/scanner/main/viewmodel/ScannerViewModel.kt
@@ -33,12 +33,9 @@ package no.nordicsemi.android.common.ui.scanner.main.viewmodel
 
 import android.os.ParcelUuid
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.stateIn
 import no.nordicsemi.android.common.ui.scanner.repository.DevicesScanFilter
 import no.nordicsemi.android.common.ui.scanner.repository.ScannerRepository
 import no.nordicsemi.android.common.ui.scanner.repository.ScanningState
@@ -67,7 +64,9 @@ internal class ScannerViewModel @Inject constructor(
                 else -> result
             }
         }
-        .stateIn(viewModelScope, SharingStarted.Lazily, ScanningState.Loading)
+        // This can't be observed in View Model Scope, as it can exist even when the
+        // scanner is not visible. Scanner state stops scanning when it is not observed.
+        // .stateIn(viewModelScope, SharingStarted.Lazily, ScanningState.Loading)
 
     private fun ScanningState.DevicesDiscovered.applyFilters(config: DevicesScanFilter) =
         ScanningState.DevicesDiscovered(devices


### PR DESCRIPTION
This PR fixes a bug in the scanner module.
Scanning flow is implemented in a way that it stops scanning when there is no one to collect the results. Before, it was observed as state in `viewModelScope`, which can long even if the scanner screen is not visible.
This PR changes the scope to the lifecycle scope of the composable.