### PR TITLE
Fix navigation issue when 2 events are emitted quickly.

### DIFF
--- a/navigation/src/main/java/no/nordicsemi/android/common/navigation/Navigator.kt
+++ b/navigation/src/main/java/no/nordicsemi/android/common/navigation/Navigator.kt
@@ -44,7 +44,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.parcelize.RawValue
-import no.nordicsemi.android.common.navigation.internal.NavigationManager
 import no.nordicsemi.android.common.navigation.internal.START_DESTINATION
 
 interface Navigator {

--- a/navigation/src/main/java/no/nordicsemi/android/common/navigation/internal/NavigationManager.kt
+++ b/navigation/src/main/java/no/nordicsemi/android/common/navigation/internal/NavigationManager.kt
@@ -61,18 +61,31 @@ import javax.inject.Inject
 @ActivityRetainedScoped
 internal class NavigationManager @Inject constructor(
     @ApplicationContext private val context: Context,
-): Navigator {
+) : Navigator {
     /** The navigation events class. */
     sealed class Event {
-        data class NavigateTo(val route: String, val args: Bundle?, val navOptions: NavOptions? = null) : Event()
-        data class NavigateUp(val result: Any?) : Event()
+        data class NavigateTo(
+            val route: String,
+            val args: Bundle?,
+            val navOptions: NavOptions? = null,
+            val counter: Int = Event.counter++
+        ) : Event()
+
+        data class NavigateUp(val result: Any?, val counter: Int = Event.counter++) : Event()
+
+        companion object {
+            private var counter = 0
+        }
     }
 
     /** Savable results that can be stored in [SavedStateHandle]. */
-    sealed class Result: Parcelable {
-        @Parcelize object Initial : Result()
-        @Parcelize object Cancelled : Result()
-        @Parcelize data class Success<R>(val value: @RawValue R) : Result()
+    sealed class Result : Parcelable {
+        @Parcelize
+        object Initial : Result()
+        @Parcelize
+        object Cancelled : Result()
+        @Parcelize
+        data class Success<R>(val value: @RawValue R) : Result()
     }
 
     private val map = mutableMapOf<DestinationId<*, *>, MutableStateFlow<Boolean>>()
@@ -150,7 +163,7 @@ internal class NavigationManager @Inject constructor(
 
     override fun open(link: Uri) {
         try {
-            with (Intent(Intent.ACTION_VIEW, link)) {
+            with(Intent(Intent.ACTION_VIEW, link)) {
                 addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                 context.startActivity(this)
             }


### PR DESCRIPTION
Quick emission of the same items is throttled by StateFlow and SharedFlow.
This results that quick multiple back navigation is impossible.
To workaround the problem the counter was added which makes equals method result different for the different events.