### PR TITLE
Adds support to consume StateFlows safely

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -48,6 +48,7 @@ dependencies {
     implementation(project(":permission"))
 
     implementation(libs.androidx.compose.material.iconsExtended)
+    implementation(libs.androidx.lifecycle.runtime.compose)
 
     implementation(libs.androidx.activity.compose)
 

--- a/app/src/main/java/no/nordicsemi/android/common/test/MainActivity.kt
+++ b/app/src/main/java/no/nordicsemi/android/common/test/MainActivity.kt
@@ -42,7 +42,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
@@ -51,6 +50,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import no.nordicsemi.android.common.logger.view.LoggerAppBarIcon
@@ -151,7 +151,8 @@ class MainActivity : NordicActivity() {
                         }
                     }
                 ) {
-                    val currentDestination by navigator.currentDestination().collectAsState()
+                    val currentDestination by navigator.currentDestination()
+                        .collectAsStateWithLifecycle()
                     Scaffold(
                         topBar = {
                             NordicAppBar(
@@ -177,10 +178,11 @@ class MainActivity : NordicActivity() {
                         },
                         bottomBar = {
                             // Show the Navigation Bar only in the Tabs destination.
-                            if (navigator.isInHierarchy(Tabs).collectAsState().value) {
+                            if (navigator.isInHierarchy(Tabs).collectAsStateWithLifecycle().value) {
                                 NavigationBar {
                                     tabs.forEach { tab ->
-                                        val selected by navigator.isInHierarchy(tab.destinationId).collectAsState()
+                                        val selected by navigator.isInHierarchy(tab.destinationId)
+                                            .collectAsStateWithLifecycle()
                                         NavigationBarItem(
                                             icon = { Icon(tab.icon, contentDescription = null) },
                                             label = { Text(tab.title) },
@@ -238,7 +240,7 @@ private fun NavigationDrawerItems(
     modifier: Modifier = Modifier,
 ) {
     items.forEach { item ->
-        val selected by navigator.isInHierarchy(item.destinationId).collectAsState()
+        val selected by navigator.isInHierarchy(item.destinationId).collectAsStateWithLifecycle()
         NavigationDrawerItem(
             icon = { Icon(item.icon, contentDescription = null) },
             label = { Text(item.title) },

--- a/app/src/main/java/no/nordicsemi/android/common/test/main/page/BasicViewsPage.kt
+++ b/app/src/main/java/no/nordicsemi/android/common/test/main/page/BasicViewsPage.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
@@ -68,7 +69,7 @@ import javax.inject.Inject
 
 val BasicsPage = PagerViewItem("Basics") {
     val vm = hiltViewModel<BasicPageViewModel>()
-    val device by vm.device.collectAsState()
+    val device by vm.device.collectAsStateWithLifecycle()
 
     BasicViewsScreen(
         device = device?.let { DeviceInfo(it) },

--- a/navigation/build.gradle.kts
+++ b/navigation/build.gradle.kts
@@ -59,5 +59,6 @@ android {
 
 dependencies {
     implementation(libs.androidx.navigation.compose)
+    implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.hilt.navigation.compose)
 }

--- a/navigation/src/main/java/no/nordicsemi/android/common/navigation/NavigationView.kt
+++ b/navigation/src/main/java/no/nordicsemi/android/common/navigation/NavigationView.kt
@@ -35,11 +35,11 @@ import android.app.Activity
 import android.os.Bundle
 import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.NavHost
@@ -74,7 +74,7 @@ fun NavigationView(
     navigation.use(navHostController.currentBackStackEntryFlow)
 
     // Handle navigation events.
-    val event by navigation.events.collectAsState()
+    val event by navigation.events.collectAsStateWithLifecycle()
 
     event?.let { e ->
         when (e) {

--- a/permission/build.gradle.kts
+++ b/permission/build.gradle.kts
@@ -64,5 +64,6 @@ dependencies {
     implementation(libs.androidx.compose.material.iconsExtended)
 
     implementation(libs.androidx.navigation.compose)
+    implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.hilt.navigation.compose)
 }

--- a/permission/src/main/java/no/nordicsemi/android/common/permission/RequireBluetooth.kt
+++ b/permission/src/main/java/no/nordicsemi/android/common/permission/RequireBluetooth.kt
@@ -33,9 +33,9 @@ package no.nordicsemi.android.common.permission
 
 import android.os.Build
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import no.nordicsemi.android.common.permission.util.Available
 import no.nordicsemi.android.common.permission.util.FeatureNotAvailableReason
 import no.nordicsemi.android.common.permission.util.NotAvailable
@@ -53,7 +53,7 @@ fun RequireBluetooth(
     content: @Composable () -> Unit,
 ) {
     val viewModel = hiltViewModel<PermissionViewModel>()
-    val state by viewModel.bluetoothState.collectAsState()
+    val state by viewModel.bluetoothState.collectAsStateWithLifecycle()
 
     onChanged(state is Available)
 

--- a/permission/src/main/java/no/nordicsemi/android/common/permission/RequireInternet.kt
+++ b/permission/src/main/java/no/nordicsemi/android/common/permission/RequireInternet.kt
@@ -32,9 +32,9 @@
 package no.nordicsemi.android.common.permission
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import no.nordicsemi.android.common.permission.util.Available
 import no.nordicsemi.android.common.permission.view.InternetNotAvailableView
 import no.nordicsemi.android.common.permission.viewmodel.PermissionViewModel
@@ -46,7 +46,7 @@ fun RequireInternet(
     content: @Composable () -> Unit
 ) {
     val viewModel = hiltViewModel<PermissionViewModel>()
-    val state by viewModel.internetPermission.collectAsState()
+    val state by viewModel.internetPermission.collectAsStateWithLifecycle()
 
     onChanged(state is Available)
 

--- a/permission/src/main/java/no/nordicsemi/android/common/permission/RequireLocation.kt
+++ b/permission/src/main/java/no/nordicsemi/android/common/permission/RequireLocation.kt
@@ -32,9 +32,9 @@
 package no.nordicsemi.android.common.permission
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import no.nordicsemi.android.common.permission.util.Available
 import no.nordicsemi.android.common.permission.util.FeatureNotAvailableReason
 import no.nordicsemi.android.common.permission.util.NotAvailable
@@ -48,7 +48,7 @@ fun RequireLocation(
     content: @Composable (isLocationRequiredAndDisabled: Boolean) -> Unit,
 ) {
     val viewModel = hiltViewModel<PermissionViewModel>()
-    val state by viewModel.locationPermission.collectAsState()
+    val state by viewModel.locationPermission.collectAsStateWithLifecycle()
 
     onChanged(state is Available || (state as NotAvailable).reason == FeatureNotAvailableReason.DISABLED)
 


### PR DESCRIPTION
* Adds support for `collectAsStateWithLifecycle()` which is the [recommended](https://medium.com/androiddevelopers/consuming-flows-safely-in-jetpack-compose-cde014d0d5a3) way to collect from StateFlows. 