### PR TITLE
Adding flags to broadcast receiver registration

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -59,4 +59,5 @@ android {
 dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.compose.ui)
+    implementation(libs.androidx.core)
 }

--- a/core/src/main/java/no/nordicsemi/android/common/core/BroadcastReceiver+Compose.kt
+++ b/core/src/main/java/no/nordicsemi/android/common/core/BroadcastReceiver+Compose.kt
@@ -39,10 +39,15 @@ import android.content.IntentFilter
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.ContextCompat
 
 @SuppressLint("ComposableNaming")
 @Composable
-fun registerReceiver(intentFilter: IntentFilter, onEvent: (Intent?) -> Unit) {
+fun registerReceiver(
+    intentFilter: IntentFilter,
+    @ContextCompat.RegisterReceiverFlags flags: Int = ContextCompat.RECEIVER_NOT_EXPORTED,
+    onEvent: (Intent?) -> Unit
+) {
     val context = LocalContext.current
 
     DisposableEffect(context) {
@@ -51,7 +56,7 @@ fun registerReceiver(intentFilter: IntentFilter, onEvent: (Intent?) -> Unit) {
                 onEvent(intent)
             }
         }
-        context.registerReceiver(broadcast, intentFilter)
+        ContextCompat.registerReceiver(context, broadcast, intentFilter, flags)
         onDispose {
             context.unregisterReceiver(broadcast)
         }

--- a/permissions-ble/src/main/java/no/nordicsemi/android/common/permissions/ble/bluetooth/BluetoothStateManager.kt
+++ b/permissions-ble/src/main/java/no/nordicsemi/android/common/permissions/ble/bluetooth/BluetoothStateManager.kt
@@ -36,6 +36,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import androidx.core.content.ContextCompat
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.callbackFlow
@@ -67,7 +68,7 @@ class BluetoothStateManager @Inject constructor(
             addAction(BluetoothAdapter.ACTION_STATE_CHANGED)
             addAction(REFRESH_PERMISSIONS)
         }
-        context.registerReceiver(bluetoothStateChangeHandler, filter)
+        ContextCompat.registerReceiver(context, bluetoothStateChangeHandler, filter, ContextCompat.RECEIVER_NOT_EXPORTED)
         awaitClose {
             context.unregisterReceiver(bluetoothStateChangeHandler)
         }

--- a/permissions-ble/src/main/java/no/nordicsemi/android/common/permissions/ble/location/LocationStateManager.kt
+++ b/permissions-ble/src/main/java/no/nordicsemi/android/common/permissions/ble/location/LocationStateManager.kt
@@ -36,6 +36,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.location.LocationManager
+import androidx.core.content.ContextCompat
 import androidx.core.location.LocationManagerCompat
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.channels.awaitClose
@@ -69,7 +70,7 @@ internal class LocationStateManager @Inject constructor(
             addAction(LocationManager.MODE_CHANGED_ACTION)
             addAction(REFRESH_PERMISSIONS)
         }
-        context.registerReceiver(locationStateChangeHandler, filter)
+        ContextCompat.registerReceiver(context, locationStateChangeHandler, filter, ContextCompat.RECEIVER_NOT_EXPORTED)
         awaitClose {
             context.unregisterReceiver(locationStateChangeHandler)
         }

--- a/permissions-nfc/src/main/java/no/nordicsemi/android/common/permissions/nfc/repostory/NfcStateManager.kt
+++ b/permissions-nfc/src/main/java/no/nordicsemi/android/common/permissions/nfc/repostory/NfcStateManager.kt
@@ -36,6 +36,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.nfc.NfcAdapter
+import androidx.core.content.ContextCompat
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.callbackFlow
@@ -72,7 +73,7 @@ internal class NfcStateManager @Inject constructor(
         val filter = IntentFilter().apply {
             addAction(NfcAdapter.ACTION_ADAPTER_STATE_CHANGED)
         }
-        context.registerReceiver(nfcStateChangeHandler, filter)
+        ContextCompat.registerReceiver(context, nfcStateChangeHandler, filter, ContextCompat.RECEIVER_NOT_EXPORTED)
         awaitClose {
             context.unregisterReceiver(nfcStateChangeHandler)
         }


### PR DESCRIPTION
This fix is required for API 34+.

This fixes this error:

![MicrosoftTeams-image](https://github.com/NordicPlayground/Android-Common-Libraries/assets/6576580/482050d6-0d0d-44c3-abff-8eb306940c2e)
