### PR TITLE
Adding flags to broadcast received registration (fix)

### DIFF
--- a/permissions-ble/src/main/java/no/nordicsemi/android/common/permissions/ble/bluetooth/BluetoothStateManager.kt
+++ b/permissions-ble/src/main/java/no/nordicsemi/android/common/permissions/ble/bluetooth/BluetoothStateManager.kt
@@ -68,7 +68,7 @@ class BluetoothStateManager @Inject constructor(
             addAction(BluetoothAdapter.ACTION_STATE_CHANGED)
             addAction(REFRESH_PERMISSIONS)
         }
-        ContextCompat.registerReceiver(context, bluetoothStateChangeHandler, filter, ContextCompat.RECEIVER_NOT_EXPORTED)
+        ContextCompat.registerReceiver(context, bluetoothStateChangeHandler, filter, ContextCompat.RECEIVER_EXPORTED)
         awaitClose {
             context.unregisterReceiver(bluetoothStateChangeHandler)
         }

--- a/permissions-ble/src/main/java/no/nordicsemi/android/common/permissions/ble/location/LocationStateManager.kt
+++ b/permissions-ble/src/main/java/no/nordicsemi/android/common/permissions/ble/location/LocationStateManager.kt
@@ -70,7 +70,7 @@ internal class LocationStateManager @Inject constructor(
             addAction(LocationManager.MODE_CHANGED_ACTION)
             addAction(REFRESH_PERMISSIONS)
         }
-        ContextCompat.registerReceiver(context, locationStateChangeHandler, filter, ContextCompat.RECEIVER_NOT_EXPORTED)
+        ContextCompat.registerReceiver(context, locationStateChangeHandler, filter, ContextCompat.RECEIVER_EXPORTED)
         awaitClose {
             context.unregisterReceiver(locationStateChangeHandler)
         }

--- a/permissions-nfc/src/main/java/no/nordicsemi/android/common/permissions/nfc/repostory/NfcStateManager.kt
+++ b/permissions-nfc/src/main/java/no/nordicsemi/android/common/permissions/nfc/repostory/NfcStateManager.kt
@@ -73,7 +73,7 @@ internal class NfcStateManager @Inject constructor(
         val filter = IntentFilter().apply {
             addAction(NfcAdapter.ACTION_ADAPTER_STATE_CHANGED)
         }
-        ContextCompat.registerReceiver(context, nfcStateChangeHandler, filter, ContextCompat.RECEIVER_NOT_EXPORTED)
+        ContextCompat.registerReceiver(context, nfcStateChangeHandler, filter, ContextCompat.RECEIVER_EXPORTED)
         awaitClose {
             context.unregisterReceiver(nfcStateChangeHandler)
         }


### PR DESCRIPTION
This PR fixes #67. As the Broadcast Receivers were not exported, they don't receive broadcasts sent by the OS.