### PR TITLE
Migration to Material3 version 1.2.0-alpha11

### DIFF
--- a/analytics/build.gradle.kts
+++ b/analytics/build.gradle.kts
@@ -63,8 +63,6 @@ dependencies {
     implementation(libs.androidx.dataStore.preferences)
     implementation(libs.androidx.hilt.navigation.compose)
 
-    implementation(libs.androidx.lifecycle.runtime.compose)
-
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.analytics)
     implementation(libs.firebase.crashlytics)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -54,8 +54,6 @@ dependencies {
 
     implementation(libs.androidx.activity.compose)
 
-    implementation(libs.nordic.blek.scanner)
-
     implementation(libs.androidx.hilt.navigation.compose)
 
     implementation(libs.androidx.lifecycle.runtime.compose)

--- a/app/src/main/java/no/nordicsemi/android/common/test/MainActivity.kt
+++ b/app/src/main/java/no/nordicsemi/android/common/test/MainActivity.kt
@@ -126,7 +126,7 @@ class MainActivity : NordicActivity() {
                                 modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding)
                             )
 
-                            Divider(
+                            HorizontalDivider(
                                 modifier = Modifier.padding(NavigationDrawerDividerDefaults.ItemPadding)
                             )
 

--- a/app/src/main/java/no/nordicsemi/android/common/test/main/page/BasicViewsPage.kt
+++ b/app/src/main/java/no/nordicsemi/android/common/test/main/page/BasicViewsPage.kt
@@ -31,14 +31,29 @@
 
 package no.nordicsemi.android.common.test.main.page
 
-import android.annotation.SuppressLint
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -48,14 +63,11 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.*
 import no.nordicsemi.android.common.navigation.Navigator
 import no.nordicsemi.android.common.test.R
 import no.nordicsemi.android.common.test.simple.Hello
 import no.nordicsemi.android.common.theme.NordicTheme
 import no.nordicsemi.android.common.theme.view.PagerViewItem
-import no.nordicsemi.android.kotlin.ble.core.ServerDevice
-import java.util.*
 import javax.inject.Inject
 
 val BasicsPage = PagerViewItem("Basics") {
@@ -73,14 +85,6 @@ class BasicPageViewModel @Inject constructor(
     fun openSimple() {
         navigator.navigateTo(Hello, 1)
     }
-}
-
-@SuppressLint("MissingPermission")
-data class DeviceInfo(
-    private val device: ServerDevice?
-) {
-    val name = device?.name ?: "Unknown"
-    val address = device?.address ?: "Unknown"
 }
 
 @Composable

--- a/app/src/main/java/no/nordicsemi/android/common/test/main/page/WizardPage.kt
+++ b/app/src/main/java/no/nordicsemi/android/common/test/main/page/WizardPage.kt
@@ -117,14 +117,15 @@ private fun WizardScreen() {
                     iconRightPadding = 24.dp,
                 )
 
-                val infiniteTransition = rememberInfiniteTransition()
+                val infiniteTransition = rememberInfiniteTransition(label = "ProgressTransition")
                 val progress by infiniteTransition.animateFloat(
                     initialValue = 0.0f,
                     targetValue = 1.0f,
                     animationSpec = infiniteRepeatable(
                         animation = tween(10000, easing = LinearEasing),
                         repeatMode = RepeatMode.Restart
-                    )
+                    ),
+                    label = "Progress"
                 )
 
                 ProgressItem(
@@ -133,8 +134,8 @@ private fun WizardScreen() {
                     iconRightPadding = 24.dp,
                 ) {
                     LinearProgressIndicator(
-                        progress = progress,
-                        modifier = Modifier.fillMaxWidth()
+                        progress = { progress },
+                        modifier = Modifier.fillMaxWidth(),
                     )
                     Text(
                         text = "%.1f%%".format(progress * 100),

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,6 +42,8 @@ leakcanary = "2.12"
 mockk = "1.13.8"
 slf4j = "2.0.9"
 robolectric = "4.11.1"
+material3 = "1.2.0-alpha11"
+material = "1.6.0-beta01"
 
 nordic-log = "2.3.0"
 nordicPlugins = "1.9.13"
@@ -58,9 +60,9 @@ androidx-benchmark-macro = { group = "androidx.benchmark", name = "benchmark-mac
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "androidxComposeBom" }
 androidx-compose-foundation = { group = "androidx.compose.foundation", name = "foundation" }
 androidx-compose-foundation-layout = { group = "androidx.compose.foundation", name = "foundation-layout" }
-androidx-compose-material = { group = "androidx.compose.material", name = "material" }
+androidx-compose-material = { group = "androidx.compose.material", name = "material", version.ref = "material" }
+androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "material3" }
 androidx-compose-material-iconsExtended = { group = "androidx.compose.material", name = "material-icons-extended" }
-androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-compose-material3-windowSizeClass = {group = "androidx.compose.material3", name = "material3-window-size-class" }
 androidx-compose-runtime = { group = "androidx.compose.runtime", name = "runtime" }
 androidx-compose-runtime-livedata = { group = "androidx.compose.runtime", name = "runtime-livedata" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,12 +1,11 @@
 [versions]
-accompanist = "0.32.0"
 androidDesugarJdkLibs = "2.0.4"
 androidGradlePlugin = "8.1.4"
 androidxActivity = "1.8.1"
 androidxAnnotation = "1.7.0"
 androidxAppCompat = "1.6.1"
 androidxComposeBom = "2023.10.01" # https://developer.android.com/jetpack/compose/bom/bom-mapping
-androidxComposeCompiler = "1.5.3" # https://developer.android.com/jetpack/androidx/releases/compose-kotlin
+androidxComposeCompiler = "1.5.4" # https://developer.android.com/jetpack/androidx/releases/compose-kotlin
 androidxComposeRuntimeTracing = "1.0.0-alpha05"
 androidxCore = "1.12.0"
 androidxCoreSplashscreen = "1.0.1"
@@ -17,7 +16,6 @@ androidxLifecycle = "2.6.2"
 androidxLocalbroadcastmanager = "1.1.0"
 androidxMacroBenchmark = "1.2.1"
 androidxNavigation = "2.7.5"
-androidxMetrics = "1.0.0-alpha04"
 androidxProfileinstaller = "1.3.1"
 androidxStartup = "1.1.1"
 androidxWindowManager = "1.2.0"
@@ -28,11 +26,9 @@ androidxTestRules = "1.5.0"
 androidxTracing = "1.1.0"
 androidxUiAutomator = "2.2.0"
 androidxWork = "2.8.1"
-coil = "2.5.0"
 firebaseBom = "32.6.0"
 hilt = "2.48.1"
 hiltExt = "1.1.0"
-jacoco = "0.8.7"
 junit4 = "4.13.2"
 kotlin = "1.9.20"
 kotlinxCoroutines = "1.7.3"
@@ -40,34 +36,13 @@ kotlinxDatetime = "0.4.1"
 kotlinxSerializationJson = "1.6.1"
 ksp = "1.9.10-1.0.13"
 lint = "31.1.4"
-memfault-cloud = "2.0.5"
-okhttp = "4.12.0"
-protobuf = "3.25.1"
-protobufPlugin = "0.9.4"
 publishPlugin = "1.2.1"
-retrofit = "2.9.0"
-retrofitKotlinxSerializationJson = "1.0.0"
-room = "2.6.0"
-secrets = "2.0.1"
-turbine = "1.0.0"
 markdown = "0.3.6"
-wirePlugin = "4.9.2"
-timber = "5.0.1"
-chart = "3.1.0"
 leakcanary = "2.12"
 mockk = "1.13.8"
 slf4j = "2.0.9"
 robolectric = "4.11.1"
-skydovesBallon = "1.6.2"
-moshiKotlin = "1.15.0"
-moshiAdapters = "1.15.0"
-moshiConverter = "2.9.0"
-moshi = "1.15.0"
-moshiKotlinCodegen = "1.15.0"
 
-nordic-blek = "1.0.9"
-nordic-ble = "2.7.2"
-nordic-dfu = "2.3.2"
 nordic-log = "2.3.0"
 nordicPlugins = "1.9.13"
 dokkaPlugin = "1.9.10"
@@ -75,12 +50,6 @@ googleServicesPlugins = "4.4.0"
 firebaseCrashlyticsPlugins = "2.9.9"
 
 [libraries]
-accompanist-flowlayout = { group = "com.google.accompanist", name = "accompanist-flowlayout", version.ref = "accompanist" }
-accompanist-swiperefresh = { group = "com.google.accompanist", name = "accompanist-swiperefresh", version.ref = "accompanist" }
-accompanist-systemuicontroller = { group = "com.google.accompanist", name = "accompanist-systemuicontroller", version.ref = "accompanist" }
-accompanist-pager = { group = "com.google.accompanist", name = "accompanist-pager", version.ref = "accompanist" }
-accompanist-pagerindicators = { group = "com.google.accompanist", name = "accompanist-pager-indicators", version.ref = "accompanist" }
-accompanist-placeholder = { group = "com.google.accompanist", name = "accompanist-placeholder-material", version.ref = "accompanist" }
 android-desugarJdkLibs = { group = "com.android.tools", name = "desugar_jdk_libs", version.ref = "androidDesugarJdkLibs" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "androidxActivity" }
 androidx-annotation = { group = "androidx.annotation", name = "annotation", version.ref = "androidxAnnotation" }
@@ -118,8 +87,6 @@ androidx-lifecycle-service = { group = "androidx.lifecycle", name = "lifecycle-s
 androidx-lifecycle-viewModel-ktx = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "androidxLifecycle" }
 androidx-lifecycle-viewModel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "androidxLifecycle" }
 androidx-lifecycle-viewModel-savedState = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-savedstate", version.ref = "androidxLifecycle" }
-androidx-localbroadcastmanager = { group = "androidx.localbroadcastmanager", name = "localbroadcastmanager", version.ref = "androidxLocalbroadcastmanager" }
-androidx-metrics = { group = "androidx.metrics", name = "metrics-performance", version.ref = "androidxMetrics" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "androidxNavigation" }
 androidx-navigation-testing = { group = "androidx.navigation", name = "navigation-testing", version.ref = "androidxNavigation" }
 androidx-profileinstaller = { group = "androidx.profileinstaller", name = "profileinstaller", version.ref = "androidxProfileinstaller" }
@@ -134,9 +101,6 @@ androidx-test-uiautomator = { group = "androidx.test.uiautomator", name = "uiaut
 androidx-tracing-ktx = {group = "androidx.tracing", name="tracing-ktx", version.ref = "androidxTracing" }
 androidx-work-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "androidxWork" }
 androidx-work-testing = { group = "androidx.work", name = "work-testing", version.ref = "androidxWork" }
-coil-kt = { group = "io.coil-kt", name = "coil", version.ref = "coil"}
-coil-kt-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil"}
-coil-kt-svg = { group = "io.coil-kt", name = "coil-svg", version.ref = "coil"}
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom"}
 firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics-ktx" }
 firebase-database = { group = "com.google.firebase", name = "firebase-database-ktx" }
@@ -155,42 +119,15 @@ kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-cor
 kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime", version.ref = "kotlinxDatetime" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 lint-api = { group = "com.android.tools.lint", name = "lint-api", version.ref = "lint" }
-okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
-protobuf-protoc = { group = "com.google.protobuf", name = "protoc", version.ref = "protobuf" }
-protobuf-kotlin-lite = { group = "com.google.protobuf", name = "protobuf-kotlin-lite", version.ref = "protobuf" }
-turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }
-retrofit-core = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
-retrofit-kotlin-serialization = { group = "com.jakewharton.retrofit", name = "retrofit2-kotlinx-serialization-converter", version.ref = "retrofitKotlinxSerializationJson" }
-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
 markdown = { group = "com.github.jeziellago", name = "compose-markdown", version.ref = "markdown" }
-memfault-cloud = { group = "com.memfault.cloud", name = "cloud-android", version.ref = "memfault-cloud" }
-timber = { group = "com.jakewharton.timber", name = "timber", version.ref = "timber" }
-chart = { group = "com.github.PhilJay", name = "MPAndroidChart", version.ref = "chart" }
 leakcanary = { group = "com.squareup.leakcanary", name = "leakcanary-android", version.ref = "leakcanary" }
 test-slf4j-simple = { group = "org.slf4j", name = "slf4j-simple", version.ref = "slf4j" }
 test-mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 test-robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
-skydoves-ballon = {group = "com.github.skydoves", name = "balloon-compose", version.ref = "skydovesBallon"}
-moshi-kotlin = {group = "com.squareup.moshi", name = "moshi-kotlin", version.ref = "moshiKotlin"}
-moshi-adapters = {group = "com.squareup.moshi", name = "moshi-adapters", version.ref = "moshiAdapters"}
-moshi-converter = {group = "com.squareup.retrofit2", name = "converter-moshi", version.ref = "moshiConverter"}
-moshi = {group = "com.squareup.moshi", name = "moshi", version.ref = "moshi"}
-moshi-kotlin-codegen = {group = "com.squareup.moshi", name = "moshi-kotlin-codegen", version.ref = "moshiKotlinCodegen"}
 
 # Nordic
 nordic-log = { group = "no.nordicsemi.android", name = "log", version.ref = "nordic-log" }
 nordic-log-timber = { group = "no.nordicsemi.android", name = "log-timber", version.ref = "nordic-log" }
-
-# BleK
-nordic-blek-client = { group = "no.nordicsemi.android.kotlin.ble", name = "client", version.ref = "nordic-blek" }
-nordic-blek-server = { group = "no.nordicsemi.android.kotlin.ble", name = "server", version.ref = "nordic-blek" }
-nordic-blek-profile = { group = "no.nordicsemi.android.kotlin.ble", name = "profile", version.ref = "nordic-blek" }
-nordic-blek-core = { group = "no.nordicsemi.android.kotlin.ble", name = "core", version.ref = "nordic-blek" }
-nordic-blek-scanner = { group = "no.nordicsemi.android.kotlin.ble", name = "scanner", version.ref = "nordic-blek" }
-nordic-blek-advertiser = { group = "no.nordicsemi.android.kotlin.ble", name = "advertiser", version.ref = "nordic-blek" }
-nordic-blek-uiscanner = { group = "no.nordicsemi.android.kotlin.ble", name = "uiscanner", version.ref = "nordic-blek" }
 
 # Dependencies of the included build-logic
 android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "androidGradlePlugin" }
@@ -216,9 +153,6 @@ kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
-protobuf = { id = "com.google.protobuf", version.ref = "protobufPlugin" }
-secrets = { id = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin", version.ref = "secrets" }
 publish = { id = "com.gradle.plugin-publish", version.ref = "publishPlugin" }
-wire = { id = "com.squareup.wire", version.ref = "wirePlugin" }
 google-services = { id = "com.google.gms.google-services", version.ref = "googleServicesPlugins" }
 firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebaseCrashlyticsPlugins" }

--- a/theme/src/main/java/no/nordicsemi/android/common/theme/NordicActivity.kt
+++ b/theme/src/main/java/no/nordicsemi/android/common/theme/NordicActivity.kt
@@ -68,7 +68,7 @@ abstract class NordicActivity : ComponentActivity() {
                 )
             } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 val flags = view.systemUiVisibility and View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR
-                view.setSystemUiVisibility(flags)
+                view.systemUiVisibility = flags
             }
         }
 

--- a/theme/src/main/java/no/nordicsemi/android/common/theme/view/NordicAppBar.kt
+++ b/theme/src/main/java/no/nordicsemi/android/common/theme/view/NordicAppBar.kt
@@ -33,7 +33,7 @@ package no.nordicsemi.android.common.theme.view
 
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
@@ -49,7 +49,7 @@ fun NordicAppBar(
     onNavigationButtonClick: (() -> Unit)? = null,
     onHamburgerButtonClick: (() -> Unit)? = null,
     showBackButton: Boolean = onNavigationButtonClick != null,
-    backButtonIcon:ImageVector = Icons.Default.ArrowBack,
+    backButtonIcon:ImageVector = Icons.AutoMirrored.Filled.ArrowBack,
     showHamburgerButton: Boolean = onHamburgerButtonClick != null,
     scrollBehavior: TopAppBarScrollBehavior? = null,
     actions: @Composable RowScope.() -> Unit = {},

--- a/theme/src/main/java/no/nordicsemi/android/common/theme/view/NordicLargeAppBar.kt
+++ b/theme/src/main/java/no/nordicsemi/android/common/theme/view/NordicLargeAppBar.kt
@@ -35,7 +35,7 @@ package no.nordicsemi.android.common.theme.view
 
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
@@ -50,7 +50,7 @@ fun NordicLargeAppBar(
     onNavigationButtonClick: (() -> Unit)? = null,
     onHamburgerButtonClick: (() -> Unit)? = null,
     showBackButton: Boolean = onNavigationButtonClick != null,
-    backButtonIcon: ImageVector = Icons.Default.ArrowBack,
+    backButtonIcon: ImageVector = Icons.AutoMirrored.Filled.ArrowBack,
     showHamburgerButton: Boolean = onHamburgerButtonClick != null,
     scrollBehavior: TopAppBarScrollBehavior? = null,
     actions: @Composable RowScope.() -> Unit = {},

--- a/theme/src/main/java/no/nordicsemi/android/common/theme/view/PagerView.kt
+++ b/theme/src/main/java/no/nordicsemi/android/common/theme/view/PagerView.kt
@@ -39,6 +39,7 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.*
+import androidx.compose.material3.TabRowDefaults.SecondaryIndicator
 import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
@@ -103,7 +104,7 @@ fun PagerView(
                 containerColor = colorResource(id = R.color.appBarColor),
                 contentColor = MaterialTheme.colorScheme.onPrimary,
                 indicator = @Composable { tabPositions ->
-                    TabRowDefaults.Indicator(
+                    SecondaryIndicator(
                         Modifier.tabIndicatorOffset(tabPositions[tabIndex]),
                         color = MaterialTheme.colorScheme.onPrimary
                     )
@@ -130,7 +131,7 @@ fun PagerView(
                 containerColor = colorResource(id = R.color.appBarColor),
                 contentColor = MaterialTheme.colorScheme.onPrimary,
                 indicator = @Composable { tabPositions ->
-                    TabRowDefaults.Indicator(
+                    SecondaryIndicator(
                         Modifier.tabIndicatorOffset(tabPositions[tabIndex]),
                         color = MaterialTheme.colorScheme.onPrimary
                     )

--- a/theme/src/main/java/no/nordicsemi/android/common/theme/view/ProgressItem.kt
+++ b/theme/src/main/java/no/nordicsemi/android/common/theme/view/ProgressItem.kt
@@ -122,8 +122,8 @@ private fun ProgressItemPreview_Working() {
             status = ProgressItemStatus.WORKING,
         ) {
             LinearProgressIndicator(
-                progress = 0.3f,
-                modifier = Modifier.fillMaxWidth()
+                progress = { 0.3f },
+                modifier = Modifier.fillMaxWidth(),
             )
             Text(
                 text = "30%",


### PR DESCRIPTION
This PR migrates the project to material3:1.2.0-alpha11.

The test app seems to compile and work, but issues may pop up later.

Also, unused dependencies are removed from toml file to avoid unnecessary Renovate updates.