### PR TITLE
Migration to Kotlin 2.0

### DIFF
--- a/analytics/build.gradle.kts
+++ b/analytics/build.gradle.kts
@@ -30,8 +30,7 @@
  */
 
 plugins {
-    alias(libs.plugins.nordic.library.compose)
-    alias(libs.plugins.nordic.hilt)
+    alias(libs.plugins.nordic.feature)
     alias(libs.plugins.nordic.nexus.android)
 }
 
@@ -57,9 +56,6 @@ dependencies {
     implementation(project(":ui"))
 
     implementation(libs.androidx.dataStore.preferences)
-    implementation(libs.androidx.hilt.navigation.compose)
-
-    implementation(libs.androidx.lifecycle.runtime.compose)
 
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.analytics)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -41,16 +41,14 @@ android {
 }
 
 dependencies {
-    implementation(project(":logger"))
-
     implementation(project(":theme"))
     implementation(project(":ui"))
+    implementation(project(":logger"))
     implementation(project(":navigation"))
     implementation(project(":permissions-ble"))
     implementation(project(":permissions-nfc"))
     implementation(project(":permissions-wifi"))
     implementation(project(":permissions-internet"))
-    implementation(project(":logger"))
 
     implementation(libs.androidx.compose.material.iconsExtended)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,6 @@
 plugins {
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.nordic.kotlin) apply false
-    alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.hilt) apply false
     alias(libs.plugins.kotlin.parcelize) apply false
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,9 +30,9 @@
  */
 plugins {
     alias(libs.plugins.android.library) apply false
-    alias(libs.plugins.nordic.kotlin) apply false
     alias(libs.plugins.hilt) apply false
     alias(libs.plugins.kotlin.parcelize) apply false
+    alias(libs.plugins.compose.compiler) apply false
 
     // Nordic plugins are defined in https://github.com/NordicSemiconductor/Android-Gradle-Plugins
     alias(libs.plugins.nordic.application.compose) apply false
@@ -41,4 +41,5 @@ plugins {
     alias(libs.plugins.nordic.feature) apply false
     alias(libs.plugins.nordic.hilt) apply false
     alias(libs.plugins.nordic.nexus.android) apply false
+    alias(libs.plugins.nordic.kotlin.android) apply false
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -56,23 +56,5 @@ android {
 }
 
 dependencies {
-    implementation(platform(libs.androidx.compose.bom))
-    implementation(libs.androidx.compose.ui)
     implementation(libs.androidx.core)
-
-    testImplementation(libs.test.mockk)
-    testImplementation(libs.junit4)
-    testImplementation(libs.kotlin.junit)
-    testImplementation(libs.androidx.test.ext)
-    testImplementation(libs.androidx.test.rules)
-    testImplementation(libs.kotlinx.coroutines.test)
-    testImplementation(libs.test.slf4j.simple)
-    testImplementation(libs.test.robolectric)
-    testImplementation(libs.hilt.android.testing)
-
-    androidTestImplementation(libs.junit4)
-    androidTestImplementation(libs.kotlin.junit)
-    androidTestImplementation(libs.androidx.test.ext)
-    androidTestImplementation(libs.androidx.test.rules)
-    androidTestImplementation(libs.kotlinx.coroutines.test)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,6 @@ androidxActivity = "1.9.0"
 androidxAnnotation = "1.8.0"
 androidxAppCompat = "1.7.0"
 androidxComposeBom = "2024.06.00" # https://developer.android.com/jetpack/compose/bom/bom-mapping
-androidxComposeCompiler = "1.5.14" # https://developer.android.com/jetpack/androidx/releases/compose-kotlin
 androidxComposeRuntimeTracing = "1.0.0-beta01"
 androidxCore = "1.13.1"
 androidxCoreSplashscreen = "1.0.1"
@@ -30,11 +29,11 @@ firebaseBom = "33.1.0"
 hilt = "2.51.1"
 hiltExt = "1.2.0"
 junit4 = "4.13.2"
-kotlin = "1.9.24"
-kotlinxCoroutines = "1.8.1"
-kotlinxDatetime = "0.5.0"
-kotlinxSerializationJson = "1.6.3"
-ksp = "1.9.23-1.0.20"
+kotlin = "2.0.0"
+kotlinxCoroutines = "1.9.0-RC"
+kotlinxDatetime = "0.6.0"
+kotlinxSerializationJson = "1.7.0"
+ksp = "2.0.0-1.0.22"
 lint = "31.5.0"
 publishPlugin = "1.2.1"
 markdown = "0.4.1"
@@ -46,7 +45,7 @@ material3 = "1.3.0-beta03"
 material = "1.6.8"
 
 nordic-log = "2.3.0"
-nordicPlugins = "2.0.1"
+nordicPlugins = "2.1"
 dokkaPlugin = "1.9.20"
 googleServicesPlugins = "4.4.2"
 firebaseCrashlyticsPlugins = "3.0.1"
@@ -57,7 +56,6 @@ androidx-activity-compose = { group = "androidx.activity", name = "activity-comp
 androidx-annotation = { group = "androidx.annotation", name = "annotation", version.ref = "androidxAnnotation" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "androidxAppCompat" }
 androidx-benchmark-macro = { group = "androidx.benchmark", name = "benchmark-macro-junit4", version.ref = "androidxMacroBenchmark" }
-androidx-compose-compiler = { group = "androidx.compose.compiler", name = "compiler", version.ref = "androidxComposeCompiler" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "androidxComposeBom" }
 androidx-compose-foundation = { group = "androidx.compose.foundation", name = "foundation" }
 androidx-compose-foundation-layout = { group = "androidx.compose.foundation", name = "foundation-layout" }
@@ -133,15 +131,16 @@ test-robolectric = { group = "org.robolectric", name = "robolectric", version.re
 nordic-log = { group = "no.nordicsemi.android", name = "log", version.ref = "nordic-log" }
 
 [plugins]
-nordic-application = { id = "no.nordicsemi.android.gradle.application", version.ref = "nordicPlugins" }
-nordic-application-compose = { id = "no.nordicsemi.android.gradle.application.compose", version.ref = "nordicPlugins" }
-nordic-library = { id = "no.nordicsemi.android.gradle.library", version.ref = "nordicPlugins" }
-nordic-library-compose = { id = "no.nordicsemi.android.gradle.library.compose", version.ref = "nordicPlugins" }
-nordic-feature = { id = "no.nordicsemi.android.gradle.feature", version.ref = "nordicPlugins" }
-nordic-hilt = { id = "no.nordicsemi.android.gradle.hilt", version.ref = "nordicPlugins" }
-nordic-kotlin = { id = "no.nordicsemi.android.gradle.kotlin", version.ref = "nordicPlugins" }
-nordic-nexus-android = { id = "no.nordicsemi.android.gradle.nexus", version.ref = "nordicPlugins" }
-nordic-nexus-kotlin = { id = "no.nordicsemi.kotlin.gradle.nexus", version.ref = "nordicPlugins" }
+nordic-application = { id = "no.nordicsemi.android.plugin.application", version.ref = "nordicPlugins" }
+nordic-application-compose = { id = "no.nordicsemi.android.plugin.application.compose", version.ref = "nordicPlugins" }
+nordic-library = { id = "no.nordicsemi.android.plugin.library", version.ref = "nordicPlugins" }
+nordic-library-compose = { id = "no.nordicsemi.android.plugin.library.compose", version.ref = "nordicPlugins" }
+nordic-feature = { id = "no.nordicsemi.android.plugin.feature", version.ref = "nordicPlugins" }
+nordic-hilt = { id = "no.nordicsemi.android.plugin.hilt", version.ref = "nordicPlugins" }
+nordic-kotlin-android = { id = "no.nordicsemi.android.plugin.kotlin", version.ref = "nordicPlugins" }
+nordic-kotlin-jvm = { id = "no.nordicsemi.jvm.plugin.kotlin", version.ref = "nordicPlugins" }
+nordic-nexus-android = { id = "no.nordicsemi.android.plugin.nexus", version.ref = "nordicPlugins" }
+nordic-nexus-kotlin = { id = "no.nordicsemi.jvm.plugin.nexus", version.ref = "nordicPlugins" }
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
 android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }
 android-test = { id = "com.android.test", version.ref = "androidGradlePlugin" }
@@ -153,6 +152,7 @@ kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 publish = { id = "com.gradle.plugin-publish", version.ref = "publishPlugin" }
 google-services = { id = "com.google.gms.google-services", version.ref = "googleServicesPlugins" }
 firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebaseCrashlyticsPlugins" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -132,10 +132,6 @@ test-robolectric = { group = "org.robolectric", name = "robolectric", version.re
 # Nordic
 nordic-log = { group = "no.nordicsemi.android", name = "log", version.ref = "nordic-log" }
 
-# Dependencies of the included build-logic
-android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "androidGradlePlugin" }
-kotlin-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
-
 [plugins]
 nordic-application = { id = "no.nordicsemi.android.gradle.application", version.ref = "nordicPlugins" }
 nordic-application-compose = { id = "no.nordicsemi.android.gradle.application.compose", version.ref = "nordicPlugins" }

--- a/logger/build.gradle.kts
+++ b/logger/build.gradle.kts
@@ -31,7 +31,6 @@
 
 plugins {
     alias(libs.plugins.nordic.library.compose)
-    alias(libs.plugins.nordic.kotlin)
     alias(libs.plugins.nordic.nexus.android)
 }
 

--- a/navigation/build.gradle.kts
+++ b/navigation/build.gradle.kts
@@ -30,8 +30,7 @@
  */
 
 plugins {
-    alias(libs.plugins.nordic.library.compose)
-    alias(libs.plugins.nordic.hilt)
+    alias(libs.plugins.nordic.feature)
     alias(libs.plugins.nordic.nexus.android)
     alias(libs.plugins.kotlin.parcelize)
 }
@@ -54,11 +53,4 @@ android {
 }
 
 dependencies {
-    implementation(libs.androidx.navigation.compose)
-    implementation(libs.androidx.hilt.navigation.compose)
-    implementation(libs.androidx.lifecycle.runtime.compose)
-
-    implementation(libs.kotlinx.coroutines.android)
-    implementation(libs.kotlinx.coroutines.core)
-    implementation(libs.kotlinx.coroutines.test)
 }

--- a/permissions-ble/build.gradle.kts
+++ b/permissions-ble/build.gradle.kts
@@ -30,8 +30,7 @@
  */
 
 plugins {
-    alias(libs.plugins.nordic.library.compose)
-    alias(libs.plugins.nordic.hilt)
+    alias(libs.plugins.nordic.feature)
     alias(libs.plugins.nordic.nexus.android)
 }
 
@@ -58,8 +57,4 @@ dependencies {
     implementation(project(":navigation"))
 
     implementation(libs.androidx.compose.material.iconsExtended)
-
-    implementation(libs.androidx.navigation.compose)
-    implementation(libs.androidx.hilt.navigation.compose)
-    implementation(libs.androidx.lifecycle.runtime.compose)
 }

--- a/permissions-internet/build.gradle.kts
+++ b/permissions-internet/build.gradle.kts
@@ -30,8 +30,7 @@
  */
 
 plugins {
-    alias(libs.plugins.nordic.library.compose)
-    alias(libs.plugins.nordic.hilt)
+    alias(libs.plugins.nordic.feature)
     alias(libs.plugins.nordic.nexus.android)
 }
 
@@ -58,8 +57,4 @@ dependencies {
     implementation(project(":navigation"))
 
     implementation(libs.androidx.compose.material.iconsExtended)
-
-    implementation(libs.androidx.navigation.compose)
-    implementation(libs.androidx.hilt.navigation.compose)
-    implementation(libs.androidx.lifecycle.runtime.compose)
 }

--- a/permissions-nfc/build.gradle.kts
+++ b/permissions-nfc/build.gradle.kts
@@ -30,8 +30,7 @@
  */
 
 plugins {
-    alias(libs.plugins.nordic.library.compose)
-    alias(libs.plugins.nordic.hilt)
+    alias(libs.plugins.nordic.feature)
     alias(libs.plugins.nordic.nexus.android)
 }
 
@@ -56,8 +55,4 @@ dependencies {
     implementation(project(":core"))
     implementation(project(":ui"))
     implementation(project(":navigation"))
-    
-    implementation(libs.androidx.navigation.compose)
-    implementation(libs.androidx.hilt.navigation.compose)
-    implementation(libs.androidx.lifecycle.runtime.compose)
 }

--- a/permissions-wifi/build.gradle.kts
+++ b/permissions-wifi/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
-    alias(libs.plugins.nordic.library.compose)
-    alias(libs.plugins.nordic.hilt)
+    alias(libs.plugins.nordic.feature)
     alias(libs.plugins.nordic.nexus.android)
 }
 group = "no.nordicsemi.android.common"
@@ -24,8 +23,4 @@ dependencies {
     implementation(project(":ui"))
 
     implementation(libs.androidx.compose.material.iconsExtended)
-
-    implementation(libs.androidx.navigation.compose)
-    implementation(libs.androidx.hilt.navigation.compose)
-    implementation(libs.androidx.lifecycle.runtime.compose)
 }

--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,7 @@
     },
     {
       "matchPackageNames": [
+        "org.slf4j:slf4j-api",
         "org.slf4j:slf4j-simple"
       ],
       "enabled": false

--- a/renovate.json
+++ b/renovate.json
@@ -10,10 +10,8 @@
   "packageRules": [
     {
       "matchPackagePatterns": [
-        "androidx.compose.compiler:compiler",
         "org.jetbrains.kotlin.*",
-        "com.google.devtools.ksp",
-        "androidx.compose.compiler"
+        "com.google.devtools.ksp"
       ],
       "groupName": "kotlin"
     },

--- a/theme/build.gradle.kts
+++ b/theme/build.gradle.kts
@@ -31,7 +31,6 @@
 
 plugins {
     alias(libs.plugins.nordic.library.compose)
-    alias(libs.plugins.nordic.hilt)
     alias(libs.plugins.nordic.nexus.android)
 }
 

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -37,7 +37,7 @@ plugins {
 group = "no.nordicsemi.android.common"
 
 nordicNexusPublishing {
-    POM_ARTIFACT_ID = "theme"
+    POM_ARTIFACT_ID = "ui"
     POM_NAME = "Nordic UI library for Android."
 
     POM_DESCRIPTION = "Nordic Android Common Libraries"

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -31,7 +31,6 @@
 
 plugins {
     alias(libs.plugins.nordic.library.compose)
-    alias(libs.plugins.nordic.hilt)
     alias(libs.plugins.nordic.nexus.android)
 }
 


### PR DESCRIPTION
This PR migrates Common project to:
* Kotlin 2.0
* Android Gradle Plugin 2.1

It also fixes modules dependencies.

Bug fix: `:ui` module artifact id fixed to `no.nordicsemi.android.common:ui`.