### PR TITLE
Remove NFC hardware restriction from manifest

### DIFF
--- a/permissions-nfc/src/main/AndroidManifest.xml
+++ b/permissions-nfc/src/main/AndroidManifest.xml
@@ -31,14 +31,6 @@
   -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-    <!--
-    Nfc permission to access the NFC hardware.
-    -->
+    <!--    Nfc permission to access the NFC hardware.    -->
     <uses-permission android:name="android.permission.NFC" />
-    <!--
-    Allow the application shows up in Google Play only for devices that have NFC hardware.
-    -->
-    <uses-feature
-        android:name="android.hardware.nfc"
-        android:required="true" />
 </manifest>


### PR DESCRIPTION
This PR eliminates the uses-feature element from the manifest file, which restricts the application's visibility on Google Play to devices equipped with NFC hardware.