### PR TITLE
Back handler fixed

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -54,7 +54,9 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/NordicTheme">
+        android:enableOnBackInvokedCallback="true"
+        android:theme="@style/NordicTheme"
+        tools:targetApi="tiramisu">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/app/src/main/java/no/nordicsemi/android/common/test/MainActivity.kt
+++ b/app/src/main/java/no/nordicsemi/android/common/test/MainActivity.kt
@@ -34,6 +34,7 @@ package no.nordicsemi.android.common.test
 import android.annotation.SuppressLint
 import android.os.Bundle
 import android.widget.Toast
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
@@ -137,6 +138,12 @@ class MainActivity : NordicActivity() {
 
                 val drawerState = rememberDrawerState(DrawerValue.Closed)
                 val scope = rememberCoroutineScope()
+
+                BackHandler(
+                    enabled = drawerState.isOpen,
+                ) {
+                    scope.launch { drawerState.close() }
+                }
 
                 ModalNavigationDrawer(
                     drawerState = drawerState,
@@ -266,14 +273,7 @@ class MainActivity : NordicActivity() {
                                 SettingsDestination,
                                 AdvancedDestination,
                             ),
-                            modifier = Modifier.padding(padding),
-                            backHandler = {
-                                // The back handler is called when user click the back button,
-                                // either the physical or any action that calls navigator.navigateUp().
-                                // The handler can handle it and return true (handled) or ignore,
-                                // to continue with a default behavior.
-                                drawerState.isOpen.also { if (it) scope.launch { drawerState.close() } }
-                            }
+                            modifier = Modifier.padding(padding)
                         )
                     }
                 }

--- a/navigation/src/main/java/no/nordicsemi/android/common/navigation/NavigationView.kt
+++ b/navigation/src/main/java/no/nordicsemi/android/common/navigation/NavigationView.kt
@@ -59,14 +59,11 @@ import no.nordicsemi.android.common.navigation.internal.navigate
  *
  * @param destinations The list of possible destinations.
  * @param modifier The modifier to be applied to the layout.
- * @param backHandler The back handler to be called when the back button is pressed. It can
- * handle the back press and return true, or return false to let the navigation view handle it.
  */
 @Composable
 fun NavigationView(
     destinations: List<NavigationDestination>,
     modifier: Modifier = Modifier,
-    backHandler: () -> Boolean = { false },
 ) {
     val navHostController = rememberNavController()
 
@@ -112,8 +109,6 @@ fun NavigationView(
         }
         navigation.consumeEvent(e)
     }
-
-    BackHandler { if (!backHandler()) navigation.navigateUp() }
 
     NavHost(
         modifier = modifier,


### PR DESCRIPTION
This PR fixes predictive back handling from Android 15+.

Setting an enabled `BackHandler` disables predictive back animation. Instead, the handler is assigned and enabled only when needed.