### PR TITLE
Firebase BOM reverted to 33.16.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,8 @@ androidxDataStore = "1.1.7"
 androidxHiltNavigationCompose = "1.2.0"
 androidxLifecycle = "2.9.2"
 androidxNavigation = "2.9.3"
-firebaseBom = "34.1.0"
+#noinspection GradleDependency
+firebaseBom = "33.16.0" # https://firebase.google.com/support/release-notes/android#2025-07-21 minSdkVersion increased from 21 to 23
 hilt = "2.57"
 hiltExt = "1.2.0"
 kotlin = "2.2.0"

--- a/renovate.json
+++ b/renovate.json
@@ -17,8 +17,7 @@
     },
     {
       "matchPackageNames": [
-        "org.slf4j:slf4j-api",
-        "org.slf4j:slf4j-simple"
+        "com.google.firebase:firebase-bom"
       ],
       "enabled": false
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -44,7 +44,6 @@ dependencyResolutionManagement {
         mavenLocal()
         google()
         mavenCentral()
-        maven(url = "https://androidx.dev/storage/compose-compiler/repository/")
     }
 }
 rootProject.name = "Common Libraries"


### PR DESCRIPTION
As 34.x increases `minSdkVersion` from 21 to 23, let's stay at 33.16 for some more time.
We don't need additional features.

More: https://firebase.google.com/support/release-notes/android#2025-07-21