### PR TITLE
Fix notification permission handling to return null when consent is not decided

### DIFF
--- a/permissions-notification/src/main/java/no/nordicsemi/android/common/permissions/notification/RequestNotificationPermission.kt
+++ b/permissions-notification/src/main/java/no/nordicsemi/android/common/permissions/notification/RequestNotificationPermission.kt
@@ -66,7 +66,7 @@ import no.nordicsemi.android.common.permissions.notification.viewmodel.Notificat
 @Composable
 fun RequestNotificationPermission(
     onChanged: (Boolean) -> Unit = {},
-    content: @Composable (Boolean) -> Unit,
+    content: @Composable (Boolean?) -> Unit,
 ) {
     val viewModel = hiltViewModel<NotificationPermissionViewModel>()
     val state by viewModel.notificationState.collectAsStateWithLifecycle()
@@ -84,7 +84,7 @@ fun RequestNotificationPermission(
                     NotificationPermissionRequestView(content)
                 }
 
-                NotAvailableReason.DENIED -> content(false)
+                NotAvailableReason.DENIED ->  content(false)
             }
         }
     }


### PR DESCRIPTION
This PR fixes the notification permission handling. If the user has neither granted nor denied consent, the function will now return null.