### PR TITLE
Revert hilt update

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,13 +6,13 @@ androidxComposeBom = "2025.09.00" # https://developer.android.com/jetpack/compos
 androidxCore = "1.17.0"
 androidxCoreSplashscreen = "1.0.1"
 androidxDataStore = "1.1.7"
-androidxHiltNavigationCompose = "1.3.0"
+androidxHiltNavigationCompose = "1.2.0"
 androidxLifecycle = "2.9.4"
 androidxNavigation = "2.9.4"
 #noinspection GradleDependency
 firebaseBom = "33.16.0" # https://firebase.google.com/support/release-notes/android#2025-07-21 minSdkVersion increased from 21 to 23
 hilt = "2.57.1"
-hiltExt = "1.3.0"
+hiltExt = "1.2.0"
 kotlin = "2.2.0"
 kotlinxCoroutines = "1.10.2"
 kotlinxDatetime = "0.7.1"


### PR DESCRIPTION
Revert the Hilt update because version 1.3.0 increases the minSDKVersion requirement from 21 to 23