### PR TITLE
Kotlin BLE Lib updated to 2.0.0-alpha15

### DIFF
--- a/gradle/nordic.versions.toml
+++ b/gradle/nordic.versions.toml
@@ -5,7 +5,7 @@
 
 [versions]
 log = "2.5.0"
-blek = "2.0.0-alpha14"
+blek = "2.0.0-alpha15"
 
 [libraries]
 log = { group = "no.nordicsemi.android", name = "log", version.ref = "log" }


### PR DESCRIPTION
Link: https://github.com/NordicSemiconductor/Kotlin-BLE-Library/releases/tag/2.0.0-alpha15