### PR TITLE
Dependencies updated

### DIFF
--- a/gradle/nordic.versions.toml
+++ b/gradle/nordic.versions.toml
@@ -5,7 +5,7 @@
 
 [versions]
 log = "2.5.0"
-blek = "2.0.0-beta02"
+blek = "2.0.0-beta03"
 
 [libraries]
 log = { group = "no.nordicsemi.android", name = "log", version.ref = "log" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -69,7 +69,7 @@ dependencyResolutionManagement {
     versionCatalogs {
         // Use Nordic Gradle Version Catalog with common external libraries versions.
         create("libs") {
-            from("no.nordicsemi.gradle:version-catalog:3.1.2-1")
+            from("no.nordicsemi.gradle:version-catalog:3.1.2-2")
         }
         // Fixed versions for Nordic libraries.
         create("nordic") {


### PR DESCRIPTION
* Nordic Version Catralog -> [3.1.2-2](https://github.com/nordicsemi/Nordic-Gradle-Plugins/releases/tag/3.1.2-2)
* Kotlin BLE Library -> [2.0.0-beta03](https://github.com/nordicsemi/Kotlin-BLE-Library/releases/tag/2.0.0-beta03)