### PR TITLE
Kotlin BLE Library updated to 2-beta4

### DIFF
--- a/gradle/nordic.versions.toml
+++ b/gradle/nordic.versions.toml
@@ -5,7 +5,7 @@
 
 [versions]
 log = "2.5.0"
-blek = "2.0.0-beta03"
+blek = "2.0.0-beta04"
 
 [libraries]
 log = { group = "no.nordicsemi.android", name = "log", version.ref = "log" }


### PR DESCRIPTION
Version details: https://github.com/nordicsemi/Kotlin-BLE-Library/releases/tag/2.0.0-beta04