### PR TITLE
[Bugfix] Changing order of reporting Bluetooth problems

### DIFF
--- a/permissions-ble/src/main/java/no/nordicsemi/android/common/permissions/ble/RequireBluetooth.kt
+++ b/permissions-ble/src/main/java/no/nordicsemi/android/common/permissions/ble/RequireBluetooth.kt
@@ -91,22 +91,19 @@ fun RequireBluetooth(
     val viewModel = hiltViewModel<PermissionViewModel>()
     val environment = viewModel.environment
     val state by environment.bluetoothState.collectAsStateWithLifecycle()
-    val bluetoothAvailable by viewModel.bluetoothPermissionFlow.collectAsStateWithLifecycle()
+    val permissionGranted by viewModel.bluetoothPermissionFlow.collectAsStateWithLifecycle()
 
-    LaunchedEffect(state, bluetoothAvailable) {
+    LaunchedEffect(state, permissionGranted) {
         val bluetoothEnabled = state == Manager.State.POWERED_ON
-        onChanged(bluetoothEnabled && bluetoothAvailable)
+        onChanged(bluetoothEnabled && permissionGranted)
     }
 
-    when (state) {
-        Manager.State.POWERED_ON -> {
-            if (bluetoothAvailable) {
-                content()
-            } else {
-                contentWithoutBluetooth(BlePermissionNotAvailableReason.PERMISSION_REQUIRED)
-            }
-        }
-        Manager.State.UNSUPPORTED -> contentWithoutBluetooth(BlePermissionNotAvailableReason.NOT_AVAILABLE)
+    when  {
+        state == Manager.State.UNSUPPORTED -> contentWithoutBluetooth(BlePermissionNotAvailableReason.NOT_AVAILABLE)
+        // First check the BLUETOOTH_CONNECT permission.
+        // It's required to enable Bluetooth.
+        !permissionGranted -> contentWithoutBluetooth(BlePermissionNotAvailableReason.PERMISSION_REQUIRED)
+        state == Manager.State.POWERED_ON -> content()
         else -> contentWithoutBluetooth(BlePermissionNotAvailableReason.DISABLED)
     }
 }


### PR DESCRIPTION
This PR changes the order in which `RequireBluetooth` reports issues with lack of required configuration.

## Before

Unsupported -> Disabled -> No permission

## After

Unsupported -> No permission -> Disabled

## Reason

To enable Bluetooth using [ACTION_REQUEST_ENABLE](https://developer.android.com/reference/android/bluetooth/BluetoothAdapter#ACTION_REQUEST_ENABLE) the app needs to have `BLUETOOTH_CONNECT` permission. Otherwise, a `SecurityException` is thrown.