### PR TITLE
Adds a composable that allows customizing scanner list items

### DIFF
--- a/scanner-ble/src/main/java/no/nordicsemi/android/common/scanner/ScanFilterState.kt
+++ b/scanner-ble/src/main/java/no/nordicsemi/android/common/scanner/ScanFilterState.kt
@@ -141,7 +141,7 @@ interface ScanFilterState {
 @Composable
 fun rememberFilterState(
     filter: ConjunctionFilterScope.() -> Unit = {},
-    scanResultFilter: (ScanResult) -> Boolean = { it.isConnectable },
+    scanResultFilter: (ScanResult) -> Boolean = { it.isConnectable != false },
     dynamicFilters: List<Filter> = listOf(
         OnlyNearby(),
         OnlyWithNames(isInitiallySelected = true),


### PR DESCRIPTION
This pull request makes a minor update to the default scan result filter logic in the `rememberFilterState` composable. The change ensures that scan results with an undefined `isConnectable` property are not excluded, improving compatibility with devices that may not explicitly set this value.

* Updated the default `scanResultFilter` lambda in `rememberFilterState` to include scan results where `isConnectable` is either `true` or `null`, instead of only `true`.